### PR TITLE
updated sbt to remove IntelliJ incompatibility

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.6.1


### PR DESCRIPTION
The current master version of this workshop chokes in IntelliJ IDEA:
```
error: error while loading String, class file '/modules/java.base/java/lang/String.class' is broken 
(class java.lang.NullPointerException/Cannot invoke "scala.tools.nsc.Global$Run.typerPhase()" because the return value of "scala.tools.nsc.Global.currentRun()" is null)
```

due to an incompatibility between it and the referenced sbt version